### PR TITLE
increase video width to 100%

### DIFF
--- a/design/scss/content.scss
+++ b/design/scss/content.scss
@@ -347,7 +347,7 @@
 
 .vid-center {
   margin: 0 auto;
-  max-width: 75%;
+  max-width: 100%;
 }
 
 video,


### PR DESCRIPTION
When viewing split-screen the video's code is unreadable due to this setting.  See before and after pictures.

![before](https://user-images.githubusercontent.com/3054831/124180530-f1f20480-da79-11eb-90ca-25ab29142163.png)
![after](https://user-images.githubusercontent.com/3054831/124180540-f4545e80-da79-11eb-9d43-fd8410be46bc.png)
